### PR TITLE
lts-13

### DIFF
--- a/hnix-lsp.cabal
+++ b/hnix-lsp.cabal
@@ -34,7 +34,7 @@ library
                      , stm
                      , unix
                      , protolude
-                     , ansi-wl-pprint
+                     , prettyprinter
                      , text
   exposed-modules:
     Nix.LSP

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,11 +1,12 @@
-resolver: lts-12.14
+resolver: lts-13.9
 
 packages:
 - .
 
 extra-deps:
-- serialise-0.2.1.0
-- haskell-lsp-0.8.0.0
-- haskell-lsp-types-0.8.0.0
+- hashing-0.1.0.1
+- monadlist-0.0.2
+- ref-tf-0.4.0.1
+- hnix-store-core-0.1.0.0
 - git: https://github.com/haskell-nix/hnix.git
-  commit: a34dddb66932b415ab837249fdad13ff910db242
+  commit: e7df5e1bd9ae91ab103605ce21d5d71309346326


### PR DESCRIPTION
It's failing since we need `errorPos :: ParseError t e -> NonEmpty SourcePos`.

So far I've been doing:

```
src/Nix/LSP.hs                let [pos] = NonEmpty.toList (errorPos err)
src/Nix/LSP.hs                    position = LSP.Position (unPos (sourceLine pos)) (unPos (sourceColumn pos))
```

So I need to extract line and column from the `ParserError`, not sure how I can do that in megaparsec 7. 

Maybe @mrkkrp could chip in? :)